### PR TITLE
Add support for `formatOptions` as a second arg to intlNumber/Date

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -41,8 +41,7 @@ See the accompanying LICENSE file for terms.
     exports.registerWith = function registerWith(Handlebars) {
         var SafeString  = Handlebars.SafeString,
             createFrame = Handlebars.createFrame,
-            escape      = Handlebars.Utils.escapeExpression,
-            extend      = Handlebars.Utils.extend;
+            escape      = Handlebars.Utils.escapeExpression;
 
         var helpers = {
             intl           : intl,
@@ -68,20 +67,18 @@ See the accompanying LICENSE file for terms.
                 throw new ReferenceError('{{#intl}} must be invoked as a block helper');
             }
 
-            // Create a new data frame linked the parent.
+            // Create a new data frame linked the parent and create a new intl
+            // data object and extend it with `options.data.intl` and
+            // `options.hash`.
             var data     = createFrame(options.data),
-                intlData = {};
+                intlData = extend({}, data.intl, options.hash);
 
-            // Create a new intl data object and extend it with
-            // `options.data.intl` and `options.hash`.
-            extend(intlData, data.intl);
-            extend(intlData, options.hash);
             data.intl = intlData;
 
             return options.fn(this, {data: data});
         }
 
-        function intlDate(date, options) {
+        function intlDate(date, formatOptions, options) {
             date = new Date(date);
 
             // Determine if the `date` is valid.
@@ -89,23 +86,53 @@ See the accompanying LICENSE file for terms.
                 throw new TypeError('A date must be provided.');
             }
 
-            var hash    = options.hash,
-                data    = options.data,
-                locales = data.intl && data.intl.locales;
-
-            return getFormat('date', locales, hash).format(date);
-        }
-
-        function intlNumber(num, options) {
-            if (typeof num !== 'number') {
-                throw new TypeError('A number must be provided.');
+            if (!options) {
+                options       = formatOptions;
+                formatOptions = null;
             }
 
             var hash    = options.hash,
                 data    = options.data,
                 locales = data.intl && data.intl.locales;
 
-            return getFormat('number', locales, hash).format(num);
+            if (formatOptions) {
+                if (typeof formatOptions === 'string') {
+                    formatOptions = intlGet('formats.date.' + format, options);
+                }
+
+                formatOptions = extend({}, formatOptions, hash);
+            } else {
+                formatOptions = hash;
+            }
+
+            return getFormat('date', locales, formatOptions).format(date);
+        }
+
+        function intlNumber(num, formatOptions, options) {
+            if (typeof num !== 'number') {
+                throw new TypeError('A number must be provided.');
+            }
+
+            if (!options) {
+                options       = formatOptions;
+                formatOptions = null;
+            }
+
+            var hash    = options.hash,
+                data    = options.data,
+                locales = data.intl && data.intl.locales;
+
+            if (formatOptions) {
+                if (typeof formatOptions === 'string') {
+                    formatOptions = intlGet('formats.number.' + format, options);
+                }
+
+                formatOptions = extend({}, formatOptions, hash);
+            } else {
+                formatOptions = hash;
+            }
+
+            return getFormat('number', locales, formatOptions).format(num);
         }
 
         function intlGet(path, options) {
@@ -257,6 +284,26 @@ See the accompanying LICENSE file for terms.
         }
 
         return format;
+    }
+
+    // -- Utilities ------------------------------------------------------------
+
+    function extend(obj) {
+        var sources = Array.prototype.slice.call(arguments, 1),
+            i, len, source, key;
+
+        for (i = 0, len = sources.length; i < len; i += 1) {
+            source = sources[i];
+            if (!source) { continue; }
+
+            for (key in source) {
+                if (source.hasOwnProperty(key)) {
+                    obj[key] = source[key];
+                }
+            }
+        }
+
+        return obj;
     }
 
     return exports;


### PR DESCRIPTION
This allows for the following:

**server.js:**

``` js
var locales = ['en-US'], 
    formats = {
        number: {
            usd: {
                style   : 'currency',
                currency: 'USD'
            }
        }
    };

res.render({
    intl: {
        locales: locales,
        formats: formats
    }
});
```

**template.hbs:**

```
{{#intl locales=intl.locales formats=intl.formats}}
    {{intlNumber 1000 'usd'}}

    or

    {{intlNumber 1000 @intl.formats.number.usd}}
{{/intl}}
```
