### PR TITLE
Usage docs update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Handlebars helpers for internationalization.
 3. Register the helpers:
 
     ```javascript
-    HandlebarsHelperIntl.register(Handlebars);
+    HandlebarsHelperIntl.registerWith(Handlebars);
     ```
 
 


### PR DESCRIPTION
The usage docs were missing from handlebars-helper-intl. 
I modeled these after the [`dust-helper-intl`](https://github.com/yahoo/dust-helper-intl) usage docs.
