### PR TITLE
Remove hard dependency on IntlMessageFormat

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   },
   "main": "index.js",
   "jsnext:main": "src/main.js",
-  "dependencies": {
-    "intl-messageformat": "^1.0.0-rc-2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "benchmark": "^1.0.0",
     "chai": "^1.9.1",
@@ -38,6 +36,7 @@
     "grunt-contrib-uglify": "^0.5.0",
     "handlebars": "^1.3.0",
     "intl": "^0.1.4",
+    "intl-messageformat": "^1.0.0-rc-2",
     "istanbul": "^0.3.0",
     "mocha": "^1.21.4",
     "xunit-file": "*"

--- a/src/formatters.js
+++ b/src/formatters.js
@@ -17,8 +17,8 @@ var formatters = {
 function getFormatter(type, locales, options) {
     var orderedOptions, option, key, i, len, id, formatter;
 
-    // When JSON is available in the environment, use it build a cache-id
-    // to reuse formatters for increased performance.
+    // When JSON is available in the environment, use it build a cache-id to
+    // reuse formatters for increased performance.
     if (JSON) {
         // Order the keys in `options` to create a serialized semantic
         // representation which is reproducible.

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,7 +6,6 @@ See the accompanying LICENSE file for terms.
 
 /* jshint esnext: true */
 
-import IntlMessageFormat from 'intl-messageformat';
 import {getFormatter} from './formatters';
 import {extend} from './utils';
 
@@ -43,9 +42,8 @@ function registerWith(Handlebars) {
             throw new ReferenceError('{{#intl}} must be invoked as a block helper');
         }
 
-        // Create a new data frame linked the parent and create a new intl
-        // data object and extend it with `options.data.intl` and
-        // `options.hash`.
+        // Create a new data frame linked the parent and create a new intl data
+        // object and extend it with `options.data.intl` and `options.hash`.
         var data     = createFrame(options.data),
             intlData = extend({}, data.intl, options.hash);
 
@@ -113,11 +111,12 @@ function registerWith(Handlebars) {
 
     function intlGet(path, options) {
         var intlData  = options.data && options.data.intl,
-            pathParts = path.split('.'),
-            obj, len, i;
+            pathParts = path.split('.');
 
-        // Use the path to walk the Intl data to find the object at the
-        // given path, and throw a descriptive error if it's not found.
+        var obj, len, i;
+
+        // Use the path to walk the Intl data to find the object at the given
+        // path, and throw a descriptive error if it's not found.
         try {
             for (i = 0, len = pathParts.length; i < len; i++) {
                 obj = intlData = intlData[pathParts[i]];
@@ -139,39 +138,29 @@ function registerWith(Handlebars) {
 
         var hash = options.hash;
 
-        // Support a message being passed as a string argument or pre-prased
-        // array. When there's no `message` argument, ensure a message path
-        // name was provided at `intlName` in the `hash`.
-        //
-        // TODO: remove support form `hash.intlName` once Handlebars bugs
-        // with subexpressions are fixed.
-        if (!(message || typeof message === 'string' || hash.intlName)) {
+        // TODO: remove support form `hash.intlName` once Handlebars bugs with
+        // subexpressions are fixed.
+        if (!(message || hash.intlName)) {
             throw new ReferenceError('{{intlMessage}} must be provided a message or intlName');
         }
 
-        var intlData = options.data.intl || {},
-            locales  = intlData.locales,
-            formats  = intlData.formats;
-
-        // Lookup message by path name. User must supply the full path to
-        // the message on `options.data.intl`.
+        // Lookup message by path name. The caller must supply the full path to
+        // the  message on `options.data.intl`.
         if (!message && hash.intlName) {
             message = intlGet(hash.intlName, options);
         }
 
         // When `message` is a function, assume it's an IntlMessageFormat
-        // instance's `format()` method passed by reference, and call it.
-        // This is possible because its `this` will be pre-bound to the
-        // instance.
+        // instance's `format()` method passed by reference, and call it. This
+        // is possible because its `this` will be pre-bound to the instance.
         if (typeof message === 'function') {
             return message(hash);
         }
 
-        // Assume that an object with a `format()` method is already an
-        // IntlMessageFormat instance, and use it; otherwise create a new
-        // one.
+        // Assume that an object with a `format()` method is an
+        // IntlMessageFormat instance, otherwise throw.
         if (typeof message.format !== 'function') {
-            message = new IntlMessageFormat(message, locales, formats);
+            throw new ReferenceError('{{intlMessage}} must be provided an IntlMessageFormat instance');
         }
 
         return message.format(hash);
@@ -180,8 +169,9 @@ function registerWith(Handlebars) {
     function intlHTMLMessage() {
         /* jshint validthis:true */
         var options = [].slice.call(arguments).pop(),
-            hash    = options.hash,
-            key, value;
+            hash    = options.hash;
+
+        var key, value;
 
         // Replace string properties in `options.hash` with HTML-escaped
         // strings.
@@ -196,8 +186,8 @@ function registerWith(Handlebars) {
             }
         }
 
-        // Return a Handlebars `SafeString`. This first unwraps the result
-        // to make sure it's not returning a double-wrapped `SafeString`.
+        // Return a Handlebars `SafeString`. This first unwraps the result to
+        // make sure it's not returning a double-wrapped `SafeString`.
         return new SafeString(String(intlMessage.apply(this, arguments)));
     }
 }

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -6,6 +6,7 @@
 var chai,
     expect,
     Handlebars,
+    IntlMessageFormat,
     timeStamp = 1390518044403;
 
 if (typeof require === 'function') {
@@ -14,6 +15,7 @@ if (typeof require === 'function') {
 
     // Intl
     global.Intl || (global.Intl = require('intl'));
+    IntlMessageFormat = require('intl-messageformat');
 
     require('../').registerWith(Handlebars);
 }
@@ -207,7 +209,7 @@ describe('Helper `intlMessage`', function () {
     it('should return a formatted string', function () {
         var tmpl = intlBlock('{{intlMessage MSG firstName=firstName lastName=lastName}}', {locales: 'en-US'}),
             out  = tmpl({
-                MSG      : 'Hi, my name is {firstName} {lastName}.',
+                MSG      : new IntlMessageFormat('Hi, my name is {firstName} {lastName}.', 'en-US'),
                 firstName: 'Anthony',
                 lastName : 'Pipkin'
             });
@@ -218,7 +220,7 @@ describe('Helper `intlMessage`', function () {
     it('should return a formatted string with formatted numbers and dates', function () {
         var tmpl = intlBlock('{{intlMessage POP_MSG city=city population=population census_date=census_date timeZone=timeZone}}', {locales: 'en-US'}),
             out  = tmpl({
-                POP_MSG    : '{city} has a population of {population, number, integer} as of {census_date, date, long}.',
+                POP_MSG    : new IntlMessageFormat('{city} has a population of {population, number, integer} as of {census_date, date, long}.', 'en-US'),
                 city       : 'Atlanta',
                 population : 5475213,
                 census_date: (new Date('1/1/2010')).getTime(),
@@ -231,7 +233,7 @@ describe('Helper `intlMessage`', function () {
     it('should return a formatted string with formatted numbers and dates in a different locale', function () {
         var tmpl = intlBlock('{{intlMessage POP_MSG city=city population=population census_date=census_date timeZone=timeZone}}', {locales: 'de-DE'}),
             out  = tmpl({
-                POP_MSG    : '{city} hat eine Bevölkerung von {population, number, integer} zum {census_date, date, long}.',
+                POP_MSG    : new IntlMessageFormat('{city} hat eine Bevölkerung von {population, number, integer} zum {census_date, date, long}.', 'de-DE'),
                 city       : 'Atlanta',
                 population : 5475213,
                 census_date: (new Date('1/1/2010')),
@@ -244,7 +246,7 @@ describe('Helper `intlMessage`', function () {
     it('should return a formatted string with an `each` block', function () {
         var tmpl = intlBlock('{{#each harvest}} {{intlMessage ../HARVEST_MSG person=person count=count }}{{/each}}', {locales: 'en-US'}),
             out  = tmpl({
-                HARVEST_MSG: '{person} harvested {count, plural, one {# apple} other {# apples}}.',
+                HARVEST_MSG: new IntlMessageFormat('{person} harvested {count, plural, one {# apple} other {# apples}}.', 'en-US'),
                 harvest    : [
                     { person: 'Allison', count: 10 },
                     { person: 'Jeremy', count: 60 }
@@ -297,16 +299,18 @@ describe('Helper `intl`', function () {
         });
 
         it('for intlMessage', function () {
+            var formats = {
+                number: {
+                    eur: { style: 'currency', currency: 'EUR' },
+                    usd: { style: 'currency', currency: 'USD' }
+                }
+            };
+
             var tmpl = '{{#intl formats=intl.formats locales="en-US"}}{{intlMessage MSG product=PRODUCT price=PRICE deadline=DEADLINE timeZone=TZ}}{{/intl}}',
                 ctx = {
-                    MSG: '{product} cost {price, number, usd} (or {price, number, eur}) if ordered by {deadline, date, long}',
+                    MSG: new IntlMessageFormat('{product} cost {price, number, usd} (or {price, number, eur}) if ordered by {deadline, date, long}', 'en-US', formats),
                     intl: {
-                        formats: {
-                            number: {
-                                eur: { style: 'currency', currency: 'EUR' },
-                                usd: { style: 'currency', currency: 'USD' }
-                            }
-                        }
+                        formats: formats
                     },
                     PRODUCT: 'oranges',
                     PRICE: 40000.004,


### PR DESCRIPTION
This removes the hard dependency on `IntlMessageFormat` in favor of pushing people towards first creating `IntlMessageFormat` instances which they then provide to Handlebars via `data.intl`.

People should not be putting literal string messages into their templates because these messages are locale-specific, instead they `IntlMessageFormat` instances should be created once, ahead of time, and then used by Handlebars during template rendering. The whole idea of this i18n suite of packages is to extract the locale-specific strings from the application's templates, code, etc.

App developers will have a collection of string-based messaged per-locale in their code repositories. When their app initializes, those string messages should be converted into `IntlMessageFormat` instances, and then used throughout the app, including used via this package.
