### PR TITLE
Add {{intlTime}} helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,12 @@ Object with user defined options for format styles. This is used to supply custo
         }
     },
 
-    date: {...}
+    date: {...},
+    time: {...}
 }
 ```
 
-These pre-defined formats can then be used by String name/path:
+These pre-defined formats map to their respective helpers of the same type, and all `data.intl.formats` are used by the `{{intlMessage}}` and `{{intlHTMLMessage}}` helpers. They can then be used by String name/path like this:
 
 ```handlebars
 {{intlNumber 100 "USD"}}
@@ -215,6 +216,10 @@ console.log(html); // => "Tuesday, August 12, 2014"
 **Hash Arguments:**
 
 The hash arguments passed to this helper become the `options` parameter value when the [`Intl.DateTimeFormat`][Intl-DTF] instance is created.
+
+#### `{{intlTime}}`
+
+This delegates to the `{{intlDate}}` helper, but first it will reference any String named `format` from [`data.intl.formats.time`](#dataintlformats).
 
 #### `{{intlNumber}}`
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -26,6 +26,7 @@ function registerWith(Handlebars) {
     var helpers = {
         intl           : intl,
         intlDate       : intlDate,
+        intlTime       : intlTime,
         intlNumber     : intlNumber,
         intlGet        : intlGet,
         intlMessage    : intlMessage,
@@ -85,6 +86,21 @@ function registerWith(Handlebars) {
         }
 
         return getDateTimeFormat(locales, formatOptions).format(date);
+    }
+
+    function intlTime(date, formatOptions, options) {
+        if (!options) {
+            options       = formatOptions;
+            formatOptions = null;
+        }
+
+        // Lookup named format on `formats.time`, before delegating to the
+        // `intlDate` helper.
+        if (formatOptions && typeof formatOptions === 'string') {
+            formatOptions = intlGet('formats.time.' + formatOptions, options);
+        }
+
+        return intlDate(date, formatOptions, options);
     }
 
     function intlNumber(num, formatOptions, options) {

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -191,6 +191,38 @@ describe('Helper `intlDate`', function () {
     });
 });
 
+describe('Helper `intlTime`', function () {
+    it('should be added to Handlebars', function () {
+        expect(Handlebars.helpers).to.include.keys('intlTime');
+    });
+
+    it('should be a function', function () {
+        expect(Handlebars.helpers.intlTime).to.be.a('function');
+    });
+
+    it('should throw if called with out a value', function () {
+        expect(Handlebars.compile('{{intlTime}}')).to.throw(TypeError);
+    });
+
+    // Use a fixed known date
+    var dateStr   = 'Thu Jan 23 2014 18:00:44 GMT-0500 (EST)',
+        timeStamp = 1390518044403;
+
+    it('should return a formatted string', function () {
+        var tmpl = intlBlock('{{intlTime "' + dateStr + '"}}', {locales: 'en-US'});
+        expect(tmpl()).to.equal('1/23/2014');
+
+        // note timestamp is passed as a number
+        tmpl = intlBlock('{{intlTime ' + timeStamp + '}}', {locales: 'en-US'});
+        expect(tmpl()).to.equal('1/23/2014');
+    });
+
+    it('should return a formatted string of just the time', function () {
+        var tmpl = intlBlock('{{intlTime ' + timeStamp + ' hour="numeric" minute="numeric" timeZone="UTC"}}', {locales: 'en-US'});
+        expect(tmpl()).to.equal('11:00 PM');
+    });
+});
+
 describe('Helper `intlMessage`', function () {
     it('should be added to Handlebars', function () {
         expect(Handlebars.helpers).to.include.keys('intlMessage');


### PR DESCRIPTION
This helper delegates to `{{intlDate}}`, but will first reference any String named `format` from `data.intl.formats.time`.

Since the pre-defined/named formats are used by `IntlMessageFormat` — which distingishes between `"date"` and `"time"` — we need a separate time helper to match.
