### PR TITLE
Use Intl.js Polyfill as `Intl` mock in unit tests

### DIFF
--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -1,4 +1,4 @@
-/* global describe, it, expect, locale, Handlebars */
+/* global describe, it, expect, locale, Intl, IntlPolyfill, Handlebars */
 /* jshint node:true, expr:true */
 
 'use strict';

--- a/tests/index.html
+++ b/tests/index.html
@@ -8,9 +8,14 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <script src="../../node_modules/intl/Intl.complete.js"></script>
+    <script>
+      // Force use of Intl.js Polyfill to serve as a mock.
+      Intl.NumberFormat   = IntlPolyfill.NumberFormat;
+      Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
+    </script>
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script src="../../node_modules/expect.js/index.js"></script>
-    <script src="../../node_modules/intl/Intl.complete.js"></script>
     <script src="../../node_modules/handlebars/dist/handlebars.js"></script>
     <script src="../../dist/handlebars-intl-with-locales.js"></script>
     <script>

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -2,9 +2,8 @@
 /* jshint node:true */
 'use strict';
 
-if (typeof Intl === 'undefined') {
-    global.Intl = require('intl');
-}
+// Force use of Intl.js Polyfill to serve as a mock.
+require('intl');
 
 global.Handlebars = require('handlebars');
 global.expect = require('expect.js');


### PR DESCRIPTION
Formatted output differs across implementations; e.g. IE11 adds bidi chars:
http://stackoverflow.com/questions/25574963/ies-tolocalestring-has-strange-characters-in-results

Therefore makes it difficult to unit test just these helpers. In order to overcome these problems, we can simply **force** the use of the Intl.js Polyfill as an `Intl` mock.
