### PR TITLE
Improve browser bundling with Browserify/Webpack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,7 @@ module.exports = function (grunt) {
                 options: {
                     prelude: [
                         '// GENERATED FILE',
-                        'var HandlebarsIntl = require("./helpers");\n\n'
+                        'var HandlebarsIntl = require("./handlebars-intl");\n\n'
                     ].join('\n'),
 
                     wrapEntry: function (entry) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 /* jshint node:true */
 'use strict';
 
-// Add all locale data to `HandlebarsIntl`.
+// Add all locale data to `HandlebarsIntl`. This module will be ignored when
+// bundling for the browser with Browserify/Webpack.
 require('./lib/locales');
 
-exports = module.exports = require('./lib/helpers');
+exports = module.exports = require('./lib/handlebars-intl');

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   },
   "main": "index.js",
   "jsnext:main": "src/main.js",
+  "browser": {
+    "./lib/locales": false,
+    "./lib/locales.js": false
+  },
   "dependencies": {
     "intl-format-cache": "2.0.2",
     "intl-messageformat": "1.0.2",

--- a/src/handlebars-intl.js
+++ b/src/handlebars-intl.js
@@ -1,0 +1,22 @@
+/*
+Copyright (c) 2014, Yahoo! Inc. All rights reserved.
+Copyrights licensed under the New BSD License.
+See the accompanying LICENSE file for terms.
+*/
+
+/* jshint esnext: true */
+
+import IntlMessageFormat from 'intl-messageformat';
+import IntlRelativeFormat from 'intl-relativeformat';
+
+import {registerWith} from './helpers.js';
+import defaultLocale from './en.js';
+
+export {registerWith};
+
+export function __addLocaleData(data) {
+    IntlMessageFormat.__addLocaleData(data);
+    IntlRelativeFormat.__addLocaleData(data);
+}
+
+__addLocaleData(defaultLocale);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -10,9 +10,9 @@ import IntlMessageFormat from 'intl-messageformat';
 import IntlRelativeFormat from 'intl-relativeformat';
 import createFormatCache from 'intl-format-cache';
 
-import {extend} from './utils';
+import {extend} from './utils.js';
 
-export {registerWith, __addLocaleData};
+export {registerWith};
 
 // -----------------------------------------------------------------------------
 
@@ -242,9 +242,4 @@ function registerWith(Handlebars) {
                 throw new Error('Unrecognized simple format type: ' + type);
         }
     }
-}
-
-function __addLocaleData(data) {
-    IntlMessageFormat.__addLocaleData(data);
-    IntlRelativeFormat.__addLocaleData(data);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,10 +6,7 @@ See the accompanying LICENSE file for terms.
 
 /* jshint esnext: true */
 
-import {registerWith, __addLocaleData} from './helpers';
-import defaultLocale from './en';
-
-__addLocaleData(defaultLocale);
+import {registerWith, __addLocaleData} from './handlebars-intl.js';
 
 // Re-export as default for
 export default {


### PR DESCRIPTION
This preps this package for `v1.0.1`, by updating the `intl-*` dependencies, and refactors this package to be more inline with how react-intl is structured.

The `"browser"` field has been added to the `package.json` to ignore all the locale data, expect English, when bundling with Browserify or Webpack.

---

~~**Note:** The build will likely fail because of https://github.com/benjamn/recast/issues/135~~
