### PR TITLE
[Enhancement] formatMessage to accept SafeString arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,10 +367,33 @@ The hash arguments represent the name/value pairs that are used to format the `m
 
 #### `{{formatHTMLMessage}}`
 
-This delegates to the `{{formatMessage}}` helper, but will first HTML-escape all of the hash argument values. This allows the `message` string to contain HTML and it will be considered safe since it's part of the template and not user-supplied data.
+This delegates to the `{{formatMessage}}` helper, but will first HTML-escape all of the hash argument values which do not return a Handlebars.SafeString. This allows the `message` string to contain HTML and it will be considered safe since it's part of the template and not user-supplied data.
 
 **Note:** The recommendation is to remove all HTML from message strings, but sometimes it can be impractical, in those cases, this helper can be used.
 
+```javascript
+Handlebars.registerHelper('strong', function (input) {
+    return new Handlebars.SafeString('<strong>' + Handlebars.Utils.escapeExpression(input) + '</strong>');
+});
+
+var html = template({visitorCount: 100}, {
+  data: {intl: inltData}
+});
+```
+
+```handlebars
+{{formatMessage "Hello visitor #{vis}!" vis=(strong (relativeNumber visitorCount))}}
+```
+
+Output:
+Hello visitor #**100**!
+
+```handlebars
+{{formatMessage "Hello visitor #<strong>{vis}</strong>!" vis=(relativeNumber visitorCount)}}
+```
+
+Output:
+Hello visitor #<strong>100</strong>!
 
 License
 -------

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -221,6 +221,45 @@ describe('Helper `formatTime`', function () {
     });
 });
 
+describe('Helper `formatHTMLMessage`', function () {
+  it('should be added to Handlebars', function () {
+    expect(Handlebars.helpers).to.have.keys('formatHTMLMessage');
+  });
+
+  it('should return html, escaping all arguments', function () {
+    var tmpl = intlBlock('{{formatHTMLMessage MSG firstName=firstName lastName=lastName}}', {locales: 'en-US'}),
+    out  = tmpl({
+      MSG      : '<strong>Hi, my name is {firstName} {lastName}.</strong>',
+      firstName: '<em>Anthony</em>',
+      lastName : 'Pipkin'
+    });
+
+    expect(out).to.equal('<strong>Hi, my name is &lt;em&gt;Anthony&lt;/em&gt; Pipkin.</strong>');
+  });
+
+  it('should return html, if an argument is a SafeString', function () {
+    var tmpl = intlBlock('{{formatHTMLMessage MSG firstName=(strong firstName) lastName=lastName}}', {locales: 'en-US'}),
+    out  = tmpl({
+      MSG      : 'Hi, my name is {firstName} {lastName}.',
+      firstName: 'Anthony',
+      lastName : 'Pipkin'
+    });
+
+    expect(out).to.equal('Hi, my name is <strong>Anthony</strong> Pipkin.');
+  });
+
+  it('should return a string, escaping all arguments', function () {
+    var tmpl = intlBlock('{{formatHTMLMessage MSG firstName=firstName lastName=lastName}}', {locales: 'en-US'}),
+    out  = tmpl({
+      MSG      : 'Hi, my name is {firstName} {lastName}.',
+      firstName: '<em>Anthony</em>',
+      lastName : '<strong>Pipkin</strong>'
+    });
+
+    expect(out).to.equal('Hi, my name is &lt;em&gt;Anthony&lt;/em&gt; &lt;strong&gt;Pipkin&lt;/strong&gt;.');
+  });
+});
+
 describe('Helper `formatMessage`', function () {
     it('should be added to Handlebars', function () {
         expect(Handlebars.helpers).to.have.keys('formatMessage');
@@ -245,6 +284,37 @@ describe('Helper `formatMessage`', function () {
             });
 
         expect(out).to.equal('Hi, my name is Anthony Pipkin.');
+    });
+
+    it('should return html for SafeString arguments and escape the rest of the options', function () {
+      var tmpl = intlBlock('{{formatMessage MSG firstName=(strong firstName) lastName=lastName}}', {locales: 'en-US'}),
+      out  = tmpl({
+        MSG      : 'Hi, my name is {firstName} {lastName}.',
+        firstName: 'Anthony',
+        lastName : '<strong>Pipkin</strong>'
+      });
+
+      expect(out).to.equal('Hi, my name is <strong>Anthony</strong> &lt;strong&gt;Pipkin&lt;/strong&gt;.');
+    });
+
+    it('should return a formatted html string when an argument is a SafeString', function () {
+      var tmpl = intlBlock('{{formatMessage MSG photos=(strong (formatNumber photos))}}', {locales: 'en-US'}),
+      out  = tmpl({
+        MSG      : '<em>Number</em> of photos: {photos}.',
+        photos   : 100
+      });
+
+      expect(out).to.equal('&lt;em&gt;Number&lt;/em&gt; of photos: <strong>100</strong>.');
+    });
+
+    it('should return a string and escape all arguments', function () {
+      var tmpl = intlBlock('{{formatMessage MSG photos=photos}}', {locales: 'en-US'}),
+      out  = tmpl({
+        MSG      : 'Number of photos: {photos}.',
+        photos   : '<strong>100</strong>'
+      });
+
+      expect(out).to.equal('Number of photos: &amp;lt;strong&amp;gt;100&amp;lt;/strong&amp;gt;.');
     });
 
     it('should return a formatted string with formatted numbers and dates', function () {

--- a/tests/runner.js
+++ b/tests/runner.js
@@ -10,4 +10,8 @@ global.expect = require('expect.js');
 
 require('../').registerWith(Handlebars);
 
+Handlebars.registerHelper('strong', function (input) {
+	return new Handlebars.SafeString('<strong>' + Handlebars.Utils.escapeExpression(input) + '</strong>');
+});
+
 require('./helpers');


### PR DESCRIPTION
This is based on a conversation I had with @ericf where he wants to support the use case of passing arguments which are SafeStrings.

```js
Handlebars.registerHelper('strong', function (input) {
  return new Handlebars.SafeString('<strong>' + input + '</strong>');
});
```
```handlebars
{{formatMessage 'Today is {date}' date=(strong (formatDate 'date'))}}
```
Outputs:
Today is **1/20/2014**

```handlebars
{{formatMessage '<em>{date}</em>' date=(strong (formatDate 'date'))}}
```
Outputs (escapes the em tags still):
`&lt;em&gt;`**1/20/2014**`&lt;/em&gt;`

Live example: http://jsbin.com/pekoxipuyo/1/edit?html,output