### PR TITLE
"Fixes" Node 0.12 tests by forcing Intl polyfill

### DIFF
--- a/tests/runner.js
+++ b/tests/runner.js
@@ -1,9 +1,11 @@
-/* global Handlebars */
+/* global Handlebars, Intl, IntlPolyfill */
 /* jshint node:true */
 'use strict';
 
 // Force use of Intl.js Polyfill to serve as a mock.
 require('intl');
+Intl.NumberFormat   = IntlPolyfill.NumberFormat;
+Intl.DateTimeFormat = IntlPolyfill.DateTimeFormat;
 
 global.Handlebars = require('handlebars');
 global.expect = require('expect.js');


### PR DESCRIPTION
This "fixes" the failing tests in Node 0.12 by forcing the use of the `Intl` polyfill. This seems to be the [only practical way][1] to test in Node 0.12 at the moment.

[1]: https://github.com/yahoo/formatjs-site/issues/178